### PR TITLE
fixed bug where 'region' was null

### DIFF
--- a/Delaunay/Site.cs
+++ b/Delaunay/Site.cs
@@ -173,6 +173,8 @@ namespace csDelaunay {
 			}
 			if (edgeOrientations == null) {
 				ReorderEdges();
+			}
+			if (region == null) {
 				region = ClipToBounds(clippingBounds);
 				if ((new Polygon(region)).PolyWinding() == Winding.CLOCKWISE) {
 					region.Reverse();


### PR DESCRIPTION
I was hitting a bug where the list of points was sometimes null when I called site.Region()

I eventually figured out that this happened whenever I called site.NeighborSites() some time before. Turns out, `edgeOrientation` is not null but `region` _is_ null if you called site.NeighborSites() before. Thus, I had to adjust the conditional a bit.