### PR TITLE
Replace Dictionary<LR, T> with a leaner construct

### DIFF
--- a/Delaunay/Edge.cs
+++ b/Delaunay/Edge.cs
@@ -132,8 +132,8 @@ namespace csDelaunay {
 
 		// Once clipVertices() is called, this Disctinary will hold two Points
 		// representing the clipped coordinates of the left and the right ends...
-		private Dictionary<LR, Vector2f> clippedVertices;
-		public Dictionary<LR, Vector2f> ClippedEnds {get{return clippedVertices;}}
+		private LRCollection<Vector2f> clippedVertices;
+		public LRCollection<Vector2f> ClippedEnds {get{return clippedVertices;}}
 
 		// Unless the entire Edge is outside the bounds.
 		// In that case visible will be false:
@@ -142,7 +142,7 @@ namespace csDelaunay {
 		}
 
 		// The two input Sites for which this Edge is a bisector:
-		private Dictionary<LR, Site> sites;
+		private LRCollection<Site> sites;
 		public Site LeftSite {get{return sites[LR.LEFT];} set{sites[LR.LEFT]=value;}}
 		public Site RightSite {get{return sites[LR.RIGHT];} set{sites[LR.RIGHT]=value;}}
 
@@ -172,7 +172,7 @@ namespace csDelaunay {
 		}
 
 		public Edge Init() {
-			sites = new Dictionary<LR, Site>();
+			sites = new LRCollection<Site>();
 
 			return this;
 		}
@@ -283,7 +283,7 @@ namespace csDelaunay {
 				}
 			}
 
-			clippedVertices = new Dictionary<LR, Vector2f>();
+			clippedVertices = new LRCollection<Vector2f>();
 			if (vertex0 == leftVertex) {
 				clippedVertices[LR.LEFT] = new Vector2f(x0, y0);
 				clippedVertices[LR.RIGHT] = new Vector2f(x1, y1);

--- a/Delaunay/LRCollection.cs
+++ b/Delaunay/LRCollection.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace csDelaunay
+{
+	public class LRCollection<T>
+	{
+		private T left;
+		private T right;
+		public T this[LR index]
+		{
+			get
+			{
+				return index == LR.LEFT ? left : right;
+			}
+			set
+			{
+				if (index == LR.LEFT)
+				{
+					left = value;
+				}
+				else
+				{
+					right = value;
+				}
+			}
+		}
+
+		public void Clear()
+		{
+			left = default(T);
+			right = default(T);
+		}
+	}
+}


### PR DESCRIPTION
Adding the first value to a Dictionary<TKey, TValue> costs more than 200 bytes and builds an empty hash table. This is wasted memory and performance.

I've done some crude benchmarks in Unity and gotten these results. Keep in mind that these numbers are from running inside the unity editor so the numbers are debug with slight overheads and garbage collects are more expensive than in traditional .NET applications. Still I think the numbers are good enough to reach a conclusion.

| Branch | Lloyd Relaxation | GC Alloc | Time ms |
| --------------- | --------------- | --------------- | --------------- |
| PouletFrit/master | 0 | 2.5 MB | 27.31 |
| Joen-UnLogick/removeLRDictionaries | 0 | 1.4 MB | 21.55 |
| PouletFrit/master | 4 | 13.0 MB | 134.36  |
| Joen-UnLogick/removeLRDictionaries | 4 | 7.5 MB | 87.16  |